### PR TITLE
Try removing leading / in .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,10 +2,10 @@
 **
 
 # Allow specifics
-!/src
-!/gradlew
-!/build.gradle.kts
-!/gradle.properties
-!/settings.gradle.kts
-!/gradle/
-!/entrypoint.sh
+!src
+!gradlew
+!build.gradle.kts
+!gradle.properties
+!settings.gradle.kts
+!gradle
+!entrypoint.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /build
 /.idea
 /.gradle
+/.kotlintest


### PR DESCRIPTION
It seems an open bug on the dockerhub builds makes it ignore lines starting !/ which is annoying