### PR TITLE
Add env var so that multiple regex can be used

### DIFF
--- a/src/main/kotlin/Config.kt
+++ b/src/main/kotlin/Config.kt
@@ -52,6 +52,7 @@ object Config {
         val retryBackoffMultiplier: Long = getEnv("K2HB_RETRY_BACKOFF_MULTIPLIER")?.toLong() ?: 2
         val regionReplication: Int = getEnv("K2HB_HBASE_REGION_REPLICATION")?.toInt() ?: 3
         val logKeys: Boolean = getEnv("K2HB_HBASE_LOG_KEYS")?.toBoolean() ?: true
+        var qualifiedTablePattern = getEnv("K2HB_QUALIFIED_TABLE_PATTERN") ?: """^\w+\.([-\w]+)\.([-\w]+)$"""
     }
 
     object Kafka {

--- a/src/main/kotlin/TextUtils.kt
+++ b/src/main/kotlin/TextUtils.kt
@@ -1,10 +1,10 @@
 class TextUtils {
+
+    private val qualifiedTablePattern = Regex(Config.Hbase.qualifiedTablePattern)
+    private val coalescedNames = mapOf("agent_core:agentToDoArchive" to "agent_core:agentToDo")
+
     fun topicNameTableMatcher(topicName: String) = qualifiedTablePattern.find(topicName)
-    private val qualifiedTablePattern = Regex("""^\w+\.([-\w]+)\.([-\w]+)$""")
 
     fun coalescedName(tableName: String) =
         if (coalescedNames[tableName] != null) coalescedNames[tableName] else tableName
-
-    private val coalescedNames = mapOf("agent_core:agentToDoArchive" to "agent_core:agentToDo")
-
 }

--- a/src/test/kotlin/TextUtilsTest.kt
+++ b/src/test/kotlin/TextUtilsTest.kt
@@ -1,4 +1,3 @@
-import arrow.core.success
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldNotBe
 import io.kotlintest.specs.StringSpec

--- a/src/test/kotlin/TextUtilsTest.kt
+++ b/src/test/kotlin/TextUtilsTest.kt
@@ -1,8 +1,9 @@
+import arrow.core.success
 import io.kotlintest.shouldBe
+import io.kotlintest.shouldNotBe
 import io.kotlintest.specs.StringSpec
 
 class TextUtilsTest : StringSpec({
-
 
     "agent_core:agentToDoArchive is coalesced." {
         val actual = TextUtils().coalescedName("agent_core:agentToDoArchive")
@@ -14,10 +15,36 @@ class TextUtilsTest : StringSpec({
         actual shouldBe "other_db:agentToDoArchive"
     }
 
-
     "Not agentToDoArchive is not coalesced." {
         val actual = TextUtils().coalescedName("core:calculationParts")
         actual shouldBe "core:calculationParts"
     }
 
+    "Test topic name table matcher will use ucfs data feed regex to match against valid table name" {
+
+        val tableName = "db.ucfs.data"
+
+        System.setProperty("K2HB_QUALIFIED_TABLE_PATTERN", """^\w+\.([-\w]+)\.([-\w]+)$""")
+
+        val result = TextUtils().topicNameTableMatcher(tableName)
+
+        result shouldNotBe null
+
+        assert(result!!.groupValues[1] == "ucfs")
+        assert(result.groupValues[2] == "data")
+    }
+
+    "Test topic name table matcher will use data equalities regex to match against valid table name" {
+
+        val tableName = "data.equalities"
+
+        Config.Hbase.qualifiedTablePattern = """([-\w]+)\.([-\w]+)"""
+
+        val result: MatchResult? = TextUtils().topicNameTableMatcher(tableName)
+
+        result shouldNotBe null
+
+        assert(result!!.groupValues[1] == "data")
+        assert(result.groupValues[2] == "equalities")
+    }
 })

--- a/src/test/kotlin/TextUtilsTest.kt
+++ b/src/test/kotlin/TextUtilsTest.kt
@@ -24,7 +24,7 @@ class TextUtilsTest : StringSpec({
 
         val tableName = "db.ucfs.data"
 
-        System.setProperty("K2HB_QUALIFIED_TABLE_PATTERN", """^\w+\.([-\w]+)\.([-\w]+)$""")
+        Config.Hbase.qualifiedTablePattern = """^\w+\.([-\w]+)\.([-\w]+)$"""
 
         val result = TextUtils().topicNameTableMatcher(tableName)
 


### PR DESCRIPTION
Pass through the regex for the qualified table name that will be used in the application.

This will allow multiple streams to be used as needed with the default sticking the same to the ucfs data feed regex.