### PR TITLE
Mock not needed in test

### DIFF
--- a/src/test/kotlin/HbaseClientTest.kt
+++ b/src/test/kotlin/HbaseClientTest.kt
@@ -71,6 +71,8 @@ class HbaseClientTest : StringSpec({
     }
 
     "Fails after max tries" {
+
+        val maxRetries = 3
         val expectedRetryMaxAttempts = Config.Hbase.retryMaxAttempts
 
         val table = mock<Table> {
@@ -89,8 +91,8 @@ class HbaseClientTest : StringSpec({
         }
 
         exception.message shouldBe errorMessage
-        verify(table, times(System.getenv("K2HB_RETRY_MAX_ATTEMPTS").toInt())).put(any<Put>())
-        verify(table, times(System.getenv("K2HB_RETRY_MAX_ATTEMPTS").toInt())).close()
+        verify(table, times(maxRetries)).put(any<Put>())
+        verify(table, times(maxRetries)).close()
         verify(table, times(expectedRetryMaxAttempts)).put(any<Put>())
     }
 

--- a/src/test/kotlin/RecordProcessorTest.kt
+++ b/src/test/kotlin/RecordProcessorTest.kt
@@ -31,7 +31,6 @@ class RecordProcessorTest : StringSpec() {
     private lateinit var mockConverter: Converter
     private lateinit var mockMessageParser: MessageParser
     private lateinit var hbaseClient: HbaseClient
-    private lateinit var metadataStoreClient: MetadataStoreClient
     private lateinit var logger: Logger
     private lateinit var processor: RecordProcessor
     private val testByteArray: ByteArray = byteArrayOf(0xA1.toByte(), 0xA1.toByte(), 0xA1.toByte(), 0xA1.toByte())
@@ -44,7 +43,6 @@ class RecordProcessorTest : StringSpec() {
         mockConverter = spy()
         mockMessageParser = mock()
         hbaseClient = mock()
-        metadataStoreClient = mock()
         logger = mock()
         processor = spy(RecordProcessor(mockValidator, mockConverter))
         doNothing().whenever(mockValidator).validate(any())


### PR DESCRIPTION
Mock isn't needed in this test, and it isn't needed at this point to be mocked so removing it fixes an issue with the config on it not working correctly. As it's gone.