### PR TITLE
Fix test breaking because of regex

### DIFF
--- a/src/test/kotlin/HbaseClientTest.kt
+++ b/src/test/kotlin/HbaseClientTest.kt
@@ -71,6 +71,8 @@ class HbaseClientTest : StringSpec({
     }
 
     "Fails after max tries" {
+
+        val maxRetries = 3
         val expectedRetryMaxAttempts = Config.Hbase.retryMaxAttempts
 
         val table = mock<Table> {
@@ -89,8 +91,8 @@ class HbaseClientTest : StringSpec({
         }
 
         exception.message shouldBe errorMessage
-        verify(table, times(System.getenv("K2HB_RETRY_MAX_ATTEMPTS").toInt())).put(any<Put>())
-        verify(table, times(System.getenv("K2HB_RETRY_MAX_ATTEMPTS").toInt())).close()
+        verify(table, times(maxRetries)).put(any<Put>())
+        verify(table, times(maxRetries)).close()
         verify(table, times(expectedRetryMaxAttempts)).put(any<Put>())
     }
 

--- a/src/test/kotlin/RecordProcessorTest.kt
+++ b/src/test/kotlin/RecordProcessorTest.kt
@@ -31,7 +31,6 @@ class RecordProcessorTest : StringSpec() {
     private lateinit var mockConverter: Converter
     private lateinit var mockMessageParser: MessageParser
     private lateinit var hbaseClient: HbaseClient
-    private lateinit var metadataStoreClient: MetadataStoreClient
     private lateinit var logger: Logger
     private lateinit var processor: RecordProcessor
     private val testByteArray: ByteArray = byteArrayOf(0xA1.toByte(), 0xA1.toByte(), 0xA1.toByte(), 0xA1.toByte())
@@ -44,7 +43,6 @@ class RecordProcessorTest : StringSpec() {
         mockConverter = spy()
         mockMessageParser = mock()
         hbaseClient = mock()
-        metadataStoreClient = mock()
         logger = mock()
         processor = spy(RecordProcessor(mockValidator, mockConverter))
         doNothing().whenever(mockValidator).validate(any())

--- a/src/test/kotlin/RecordProcessorTest.kt
+++ b/src/test/kotlin/RecordProcessorTest.kt
@@ -47,7 +47,6 @@ class RecordProcessorTest : StringSpec() {
         processor = spy(RecordProcessor(mockValidator, mockConverter))
         doNothing().whenever(mockValidator).validate(any())
         doNothing().whenever(processor).sendMessageToDlq(any(), any())
-        Config.Hbase.qualifiedTablePattern = """^\w+\.([-\w]+)\.([-\w]+)$"""
     }
 
     init {

--- a/src/test/kotlin/RecordProcessorTest.kt
+++ b/src/test/kotlin/RecordProcessorTest.kt
@@ -47,6 +47,7 @@ class RecordProcessorTest : StringSpec() {
         processor = spy(RecordProcessor(mockValidator, mockConverter))
         doNothing().whenever(mockValidator).validate(any())
         doNothing().whenever(processor).sendMessageToDlq(any(), any())
+        Config.Hbase.qualifiedTablePattern = """^\w+\.([-\w]+)\.([-\w]+)$"""
     }
 
     init {

--- a/src/test/kotlin/TextUtilsTest.kt
+++ b/src/test/kotlin/TextUtilsTest.kt
@@ -35,6 +35,8 @@ class TextUtilsTest : StringSpec({
 
         assert(result!!.groupValues[1] == "ucfs")
         assert(result.groupValues[2] == "data")
+
+        reset()
     }
 
     "Test topic name table matcher will use data equalities regex to match against valid table name" {
@@ -49,5 +51,7 @@ class TextUtilsTest : StringSpec({
 
         assert(result!!.groupValues[1] == "data")
         assert(result.groupValues[2] == "equalities")
+
+        reset()
     }
 })

--- a/src/test/kotlin/TextUtilsTest.kt
+++ b/src/test/kotlin/TextUtilsTest.kt
@@ -4,6 +4,10 @@ import io.kotlintest.specs.StringSpec
 
 class TextUtilsTest : StringSpec({
 
+    fun reset() {
+        Config.Hbase.qualifiedTablePattern = """^\w+\.([-\w]+)\.([-\w]+)$"""
+    }
+
     "agent_core:agentToDoArchive is coalesced." {
         val actual = TextUtils().coalescedName("agent_core:agentToDoArchive")
         actual shouldBe "agent_core:agentToDo"


### PR DESCRIPTION
TextUtilsTest is changing the config regex which is causing other takes to break.

RecordProcessorTest is now resetting the config back to the expected state that it wants.