### PR TITLE
Support blank record key in dql actions. Support dots in table names.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -98,7 +98,7 @@ tasks.register<Test>("integration-test-equality") {
     environment("K2HB_RETRY_BACKOFF_MULTIPLIER", "1")
     environment("K2HB_VALIDATOR_SCHEMA", "equality_message.schema.json")
     environment("K2HB_QUALIFIED_TABLE_PATTERN", """([-\w]+)\.([-\w]+)""")
-    environment("K2HB_KAFKA_TOPIC_REGEX", "^data.(.*)")
+    environment("K2HB_KAFKA_TOPIC_REGEX", """^(data[.][-\w]+)$""")
 
     testLogging {
         outputs.upToDateWhen {false}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -97,6 +97,7 @@ tasks.register<Test>("integration-test-equality") {
     environment("K2HB_RETRY_MAX_ATTEMPTS", "3")
     environment("K2HB_RETRY_BACKOFF_MULTIPLIER", "1")
     environment("K2HB_VALIDATOR_SCHEMA", "equality_message.schema.json")
+    environment("K2HB_WRITE_TO_METADATA_STORE", "true")
     environment("K2HB_QUALIFIED_TABLE_PATTERN", """([-\w]+)\.([-\w]+)""")
     environment("K2HB_KAFKA_TOPIC_REGEX", """^(data[.][-\w]+)$""")
 
@@ -122,6 +123,7 @@ tasks.register<Test>("integration-load-test") {
     environment("K2HB_RETRY_MAX_ATTEMPTS", "3")
     environment("K2HB_RETRY_BACKOFF_MULTIPLIER", "1")
     environment("K2HB_USE_AWS_SECRETS", "false")
+    environment("K2HB_WRITE_TO_METADATA_STORE", "true")
 
     testLogging {
         outputs.upToDateWhen {false}
@@ -141,6 +143,7 @@ tasks.register<Test>("unit") {
     environment("K2HB_RETRY_MAX_ATTEMPTS", "3")
     environment("K2HB_RETRY_BACKOFF_MULTIPLIER", "1")
     environment("K2HB_USE_AWS_SECRETS", "false")
+    environment("K2HB_WRITE_TO_METADATA_STORE", "true")
 
     testLogging {
         outputs.upToDateWhen {false}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -48,8 +48,6 @@ services:
       K2HB_APP_VERSION: "test"
       INSTANCE_ID: "localhost"
       K2HB_KAFKA_INSECURE: "true"
-      K2HB_KAFKA_TOPIC_REGEX: ^(db[.]{1}[-\w]+[.]{1}[-\w]+)$
-      K2HB_QUALIFIED_TABLE_PATTERN: ^\w+\.([-\w]+)\.([-.\w]+)$
       K2HB_KAFKA_META_REFRESH_MS: "1000"
       K2HB_KAFKA_POLL_TIMEOUT: "PT10S"
       K2HB_RETRY_MAX_ATTEMPTS: "3"
@@ -72,6 +70,8 @@ services:
       AWS_SECRET_ACCESS_KEY: "aws-secret-access-key"
       K2HB_IMAGE_DIGEST: "latest"
       K2HB_WRITE_TO_METADATA_STORE: "true"
+      # use default, which is K2HB_KAFKA_TOPIC_REGEX: ^(db[.]{1}[-\w]+[.]{1}[-\w]+)$
+      K2HB_QUALIFIED_TABLE_PATTERN: \w+\.([-\w]+)\.([-.\w]+)
 
   kafka2hbaseequality:
     image: kafka2hbase:latest
@@ -112,8 +112,8 @@ services:
       AWS_SECRET_ACCESS_KEY: "aws-secret-access-key"
       K2HB_IMAGE_DIGEST: "latest"
       K2HB_VALIDATOR_SCHEMA: "equality_message.schema.json"
+      K2HB_KAFKA_TOPIC_REGEX: (data[.][-\w]+)
       K2HB_QUALIFIED_TABLE_PATTERN: ([-\w]+)\.([-\w]+)
-      K2HB_KAFKA_TOPIC_REGEX: ^(data[.][-\w]+)$
 
   kafka2s3:
     image: dwpdigital/kafka-to-s3:latest

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -48,7 +48,7 @@ services:
       K2HB_APP_VERSION: "test"
       INSTANCE_ID: "localhost"
       K2HB_KAFKA_INSECURE: "true"
-      K2HB_KAFKA_TOPIC_REGEX: "^db.(.*)"
+      K2HB_KAFKA_TOPIC_REGEX: ^(db[.]{1}[-\w]+[.]{1}[-\w]+)\$
       K2HB_KAFKA_META_REFRESH_MS: "1000"
       K2HB_KAFKA_POLL_TIMEOUT: "PT10S"
       K2HB_RETRY_MAX_ATTEMPTS: "3"
@@ -112,7 +112,7 @@ services:
       K2HB_IMAGE_DIGEST: "latest"
       K2HB_VALIDATOR_SCHEMA: "equality_message.schema.json"
       K2HB_QUALIFIED_TABLE_PATTERN: ([-\w]+)\.([-\w]+)
-      K2HB_KAFKA_TOPIC_REGEX: "^data.(.*)"
+      K2HB_KAFKA_TOPIC_REGEX: ^(data[.][-\w]+)$
 
   kafka2s3:
     image: dwpdigital/kafka-to-s3:latest

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -48,7 +48,8 @@ services:
       K2HB_APP_VERSION: "test"
       INSTANCE_ID: "localhost"
       K2HB_KAFKA_INSECURE: "true"
-      K2HB_KAFKA_TOPIC_REGEX: ^(db[.]{1}[-\w]+[.]{1}[-\w]+)\$
+      K2HB_KAFKA_TOPIC_REGEX: ^(db[.]{1}[-\w]+[.]{1}[-\w]+)$
+      K2HB_QUALIFIED_TABLE_PATTERN: ^\w+\.([-\w]+)\.([-.\w]+)$
       K2HB_KAFKA_META_REFRESH_MS: "1000"
       K2HB_KAFKA_POLL_TIMEOUT: "PT10S"
       K2HB_RETRY_MAX_ATTEMPTS: "3"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -70,7 +70,7 @@ services:
       AWS_SECRET_ACCESS_KEY: "aws-secret-access-key"
       K2HB_IMAGE_DIGEST: "latest"
       K2HB_WRITE_TO_METADATA_STORE: "true"
-      # use default, which is K2HB_KAFKA_TOPIC_REGEX: ^(db[.]{1}[-\w]+[.]{1}[-\w]+)$
+      K2HB_KAFKA_TOPIC_REGEX: (db[.]{1}[-\w]+[.]{1}[-\w]+)
       K2HB_QUALIFIED_TABLE_PATTERN: \w+\.([-\w]+)\.([-.\w]+)
 
   kafka2hbaseequality:

--- a/src/integration/kotlin/Kafka2hbEqualityIntegrationSpec.kt
+++ b/src/integration/kotlin/Kafka2hbEqualityIntegrationSpec.kt
@@ -75,7 +75,7 @@ class Kafka2hbEqualityIntegrationSpec : StringSpec() {
             if (matcher1 != null) {
                 val namespace = matcher1.groupValues[1]
                 val tableName = matcher1.groupValues[2]
-                val qualifiedTableName = "$namespace:$tableName".replace("-", "_")
+                val qualifiedTableName = "$namespace:$tableName".replace("-", "_").replace(".", "_")
                 val kafkaTimestamp1 = converter.getTimestampAsLong(getISO8601Timestamp())
                 hbase.putVersion(qualifiedTableName, key, body1, kafkaTimestamp1)
             }
@@ -96,7 +96,7 @@ class Kafka2hbEqualityIntegrationSpec : StringSpec() {
             if (matcher != null) {
                 val namespace = matcher.groupValues[1]
                 val tableName = matcher.groupValues[2]
-                val qualifiedTableName = "$namespace:$tableName".replace("-", "_")
+                val qualifiedTableName = "$namespace:$tableName".replace("-", "_").replace(".", "_")
                 val storedNewValue =
                     waitFor { hbase.getCellAfterTimestamp(qualifiedTableName, key, referenceTimestamp) }
                 Gson().fromJson(

--- a/src/integration/kotlin/Kafka2hbEqualityIntegrationSpec.kt
+++ b/src/integration/kotlin/Kafka2hbEqualityIntegrationSpec.kt
@@ -36,7 +36,7 @@ class Kafka2hbEqualityIntegrationSpec : StringSpec() {
             if (matcher != null) {
                 val namespace = matcher.groupValues[1]
                 val tableName = matcher.groupValues[2]
-                val qualifiedTableName = "$namespace:$tableName".replace("-", "_")
+                val qualifiedTableName = sampleQualifiedTableName(namespace, tableName)
                 hbase.ensureTable(qualifiedTableName)
                 val s3Client = getS3Client()
                 val summaries = s3Client.listObjectsV2("kafka2s3", "prefix").objectSummaries
@@ -75,7 +75,7 @@ class Kafka2hbEqualityIntegrationSpec : StringSpec() {
             if (matcher1 != null) {
                 val namespace = matcher1.groupValues[1]
                 val tableName = matcher1.groupValues[2]
-                val qualifiedTableName = "$namespace:$tableName".replace("-", "_").replace(".", "_")
+                val qualifiedTableName = sampleQualifiedTableName(namespace, tableName)
                 val kafkaTimestamp1 = converter.getTimestampAsLong(getISO8601Timestamp())
                 hbase.putVersion(qualifiedTableName, key, body1, kafkaTimestamp1)
             }
@@ -96,7 +96,7 @@ class Kafka2hbEqualityIntegrationSpec : StringSpec() {
             if (matcher != null) {
                 val namespace = matcher.groupValues[1]
                 val tableName = matcher.groupValues[2]
-                val qualifiedTableName = "$namespace:$tableName".replace("-", "_").replace(".", "_")
+                val qualifiedTableName = sampleQualifiedTableName(namespace, tableName)
                 val storedNewValue =
                     waitFor { hbase.getCellAfterTimestamp(qualifiedTableName, key, referenceTimestamp) }
                 Gson().fromJson(

--- a/src/integration/kotlin/Kafka2hbIntegrationLoadSpec.kt
+++ b/src/integration/kotlin/Kafka2hbIntegrationLoadSpec.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import lib.getISO8601Timestamp
+import lib.sampleQualifiedTableName
 import lib.sendRecord
 import org.apache.hadoop.hbase.TableName
 import org.apache.hadoop.hbase.client.Scan
@@ -62,8 +63,8 @@ class Kafka2hbIntegrationLoadSpec : StringSpec() {
             }
 
             println("Checking metadatastore")
-            val connection = metadataStoreConnection()
-            connection.use { connection ->
+            val newConnection = metadataStoreConnection()
+            newConnection.use { connection ->
                 connection.createStatement().use { statement ->
                     val results = statement.executeQuery("SELECT count(*) FROM ucfs")
                     results.next() shouldBe true
@@ -91,9 +92,8 @@ class Kafka2hbIntegrationLoadSpec : StringSpec() {
             .map { it.nameAsString }
             .filter { Regex(tableNamePattern()).matches(it) }
 
-    private fun tableName(it: Int) = "$DB_NAME$it:$COLLECTION_NAME$it".replace("-", "_")
-
-    private fun tableNamePattern() = """$DB_NAME\d+:$COLLECTION_NAME\d+""".replace("-", "_")
+    private fun tableName(counter: Int) = sampleQualifiedTableName("$DB_NAME$counter", "COLLECTION_NAME$counter")
+    private fun tableNamePattern() = """$DB_NAME\d+:$COLLECTION_NAME\d+""".replace("-", "_").replace(".", "_")
 
     private fun topicName(collectionNumber: Int)
             = "db.$DB_NAME$collectionNumber.$COLLECTION_NAME$collectionNumber"

--- a/src/integration/kotlin/Kafka2hbIntegrationSpec.kt
+++ b/src/integration/kotlin/Kafka2hbIntegrationSpec.kt
@@ -36,7 +36,7 @@ class Kafka2hbIntegrationSpec : StringSpec() {
             if (matcher != null) {
                 val namespace = matcher.groupValues[1]
                 val tableName = matcher.groupValues[2]
-                val qualifiedTableName = "$namespace:$tableName".replace("-", "_")
+                val qualifiedTableName = "$namespace:$tableName".replace("-", "_").replace(".", "_")
                 hbase.ensureTable(qualifiedTableName)
                 val s3Client = getS3Client()
                 val summaries = s3Client.listObjectsV2("kafka2s3", "prefix").objectSummaries
@@ -97,7 +97,7 @@ class Kafka2hbIntegrationSpec : StringSpec() {
             if (matcher1 != null) {
                 val namespace = matcher1.groupValues[1]
                 val tableName = matcher1.groupValues[2]
-                val qualifiedTableName = "$namespace:$tableName".replace("-", "_")
+                val qualifiedTableName = "$namespace:$tableName".replace("-", "_").replace(".", "_")
                 val kafkaTimestamp1 = converter.getTimestampAsLong(getISO8601Timestamp())
                 hbase.putVersion(qualifiedTableName, key, body1, kafkaTimestamp1)
             }
@@ -118,7 +118,7 @@ class Kafka2hbIntegrationSpec : StringSpec() {
             if (matcher != null) {
                 val namespace = matcher.groupValues[1]
                 val tableName = matcher.groupValues[2]
-                val qualifiedTableName = "$namespace:$tableName".replace("-", "_")
+                val qualifiedTableName = "$namespace:$tableName".replace("-", "_").replace(".", "_")
                 val storedNewValue =
                     waitFor { hbase.getCellAfterTimestamp(qualifiedTableName, key, referenceTimestamp) }
                 Gson().fromJson(

--- a/src/integration/kotlin/Kafka2hbIntegrationSpec.kt
+++ b/src/integration/kotlin/Kafka2hbIntegrationSpec.kt
@@ -36,7 +36,7 @@ class Kafka2hbIntegrationSpec : StringSpec() {
             if (matcher != null) {
                 val namespace = matcher.groupValues[1]
                 val tableName = matcher.groupValues[2]
-                val qualifiedTableName = "$namespace:$tableName".replace("-", "_").replace(".", "_")
+                val qualifiedTableName = sampleQualifiedTableName(namespace, tableName)
                 hbase.ensureTable(qualifiedTableName)
                 val s3Client = getS3Client()
                 val summaries = s3Client.listObjectsV2("kafka2s3", "prefix").objectSummaries
@@ -97,7 +97,7 @@ class Kafka2hbIntegrationSpec : StringSpec() {
             if (matcher1 != null) {
                 val namespace = matcher1.groupValues[1]
                 val tableName = matcher1.groupValues[2]
-                val qualifiedTableName = "$namespace:$tableName".replace("-", "_").replace(".", "_")
+                val qualifiedTableName = sampleQualifiedTableName(namespace, tableName)
                 val kafkaTimestamp1 = converter.getTimestampAsLong(getISO8601Timestamp())
                 hbase.putVersion(qualifiedTableName, key, body1, kafkaTimestamp1)
             }
@@ -118,7 +118,7 @@ class Kafka2hbIntegrationSpec : StringSpec() {
             if (matcher != null) {
                 val namespace = matcher.groupValues[1]
                 val tableName = matcher.groupValues[2]
-                val qualifiedTableName = "$namespace:$tableName".replace("-", "_").replace(".", "_")
+                val qualifiedTableName = sampleQualifiedTableName(namespace, tableName)
                 val storedNewValue =
                     waitFor { hbase.getCellAfterTimestamp(qualifiedTableName, key, referenceTimestamp) }
                 Gson().fromJson(

--- a/src/integration/kotlin/lib/RecordData.kt
+++ b/src/integration/kotlin/lib/RecordData.kt
@@ -63,3 +63,6 @@ fun getISO8601Timestamp(): String {
 fun uniqueTopicName() = "db.database.collection_${Instant.now().toEpochMilli()}"
 
 fun uniqueEqualityTopicName() = "data.equality_${Instant.now().toEpochMilli()}"
+
+fun sampleQualifiedTableName(namespace: String, tableName: String) =
+    "$namespace:$tableName".replace("-", "_").replace(".", "_")

--- a/src/main/kotlin/BaseProcessor.kt
+++ b/src/main/kotlin/BaseProcessor.kt
@@ -6,36 +6,49 @@ import org.apache.kafka.clients.producer.ProducerRecord
 open class BaseProcessor(private val validator: Validator, private val converter: Converter) {
 
     open fun recordAsJson(record: ConsumerRecord<ByteArray, ByteArray>) =
-            try {
-                converter.convertToJson(record.value()).let { json ->
-                    validator.validate(json.toJsonString())
-                    json
-                }
-            } catch (e: IllegalArgumentException) {
-                logger.warn("Could not parse message body", "record", getDataStringForRecord(record))
-                sendMessageToDlq(record, "Invalid json")
-                null
-            } catch (e: InvalidMessageException) {
-                logger.warn("Schema validation error", "record", getDataStringForRecord(record), "message", "${e.message}")
-                sendMessageToDlq(record, "Invalid schema for ${getDataStringForRecord(record)}: ${e.message}")
-                null
+        try {
+            converter.convertToJson(record.value()).let { json ->
+                validator.validate(json.toJsonString())
+                json
             }
+        } catch (e: IllegalArgumentException) {
+            logger.warn("Could not parse message body", "record", getDataStringForRecord(record))
+            sendMessageToDlq(record, "Invalid json")
+            null
+        } catch (e: InvalidMessageException) {
+            logger.warn("Schema validation error", "record", getDataStringForRecord(record), "message", "${e.message}")
+            sendMessageToDlq(record, "Invalid schema for ${getDataStringForRecord(record)}: ${e.message}")
+            null
+        }
 
     open fun sendMessageToDlq(record: ConsumerRecord<ByteArray, ByteArray>, reason: String) {
         val body = record.value()
-        logger.warn("Error processing record, sending to dlq", "reason", reason, "key", String(record.key()))
+        val originalTopic = record.topic().toString()
+        val originalOffset = record.offset().toString()
+        val recordKey: ByteArray? = if (record.key() != null) record.key() else null
+        val stringKey = if (recordKey != null) String(recordKey) else "UNKNOWN"
+        logger.warn("Error processing record, sending to dlq", "reason", reason, "key", stringKey)
 
         try {
-            val malformedRecord = MalformedRecord(String(record.key()), String(body), reason)
+            val malformedRecord = MalformedRecord(stringKey, String(body), reason)
             val jsonString = Klaxon().toJsonString(malformedRecord)
             val producerRecord =
-                    ProducerRecord(dlqTopic,null,null, record.key(),jsonString.toByteArray(),null)
+                ProducerRecord(dlqTopic, null, null, recordKey, jsonString.toByteArray(), null)
+
+            logger.info(
+                "Sending message to dlq", "key", stringKey, "original_topic", originalTopic,
+                "original_offset", originalOffset
+            )
             val metadata = DlqProducer.getInstance()?.send(producerRecord)?.get()
-            logger.info("Sending message to dlq","key", String(record.key()), "topic",
-                    metadata?.topic().toString(), "offset", "${metadata?.offset()}")
+            logger.info(
+                "Sent message to dlq", "key", stringKey, "dlq_topic",
+                metadata?.topic().toString(), "dlq_offset", "${metadata?.offset()}"
+            )
         } catch (e: Exception) {
-            logger.error("Error sending message to dlq",
-                    "key", String(record.key()), "topic", record.topic(), "offset", "${record.offset()}")
+            logger.error(
+                "Error sending message to dlq",
+                "key", stringKey, "original_topic", originalTopic, "original_offset", originalOffset
+            )
             throw DlqException("Exception while sending message to DLQ : $e")
         }
     }

--- a/src/main/kotlin/Config.kt
+++ b/src/main/kotlin/Config.kt
@@ -107,7 +107,7 @@ object Config {
         }
 
         val pollTimeout: Duration = getEnv("K2HB_KAFKA_POLL_TIMEOUT")?.toDuration() ?: Duration.ofSeconds(3)
-        var topicRegex: Pattern = Pattern.compile(getEnv("K2HB_KAFKA_TOPIC_REGEX") ?: "db.*")
+        var topicRegex: Pattern = Pattern.compile(getEnv("K2HB_KAFKA_TOPIC_REGEX") ?: """^(db[.]{1}[-\w]+[.]{1}[-\w]+)\$""")
         var dlqTopic = getEnv("K2HB_KAFKA_DLQ_TOPIC") ?: "test-dlq-topic"
 
         fun metadataRefresh(): String = consumerProps.getProperty(metaDataRefreshKey)

--- a/src/main/kotlin/Config.kt
+++ b/src/main/kotlin/Config.kt
@@ -62,7 +62,8 @@ object Config {
         val retryBackoffMultiplier: Long = getEnv("K2HB_RETRY_BACKOFF_MULTIPLIER")?.toLong() ?: 2
         val regionReplication: Int = getEnv("K2HB_HBASE_REGION_REPLICATION")?.toInt() ?: 3
         val logKeys: Boolean = getEnv("K2HB_HBASE_LOG_KEYS")?.toBoolean() ?: true
-        var qualifiedTablePattern = getEnv("K2HB_QUALIFIED_TABLE_PATTERN") ?: """^\w+\.([-\w]+)\.([-\w]+)$"""
+        var DEFAULT_QUALIFIED_TABLE_PATTERN = """^\w+\.([-\w]+)\.([-.\w]+)$"""
+        var qualifiedTablePattern = getEnv("K2HB_QUALIFIED_TABLE_PATTERN") ?: DEFAULT_QUALIFIED_TABLE_PATTERN
     }
 
     object Kafka {

--- a/src/main/kotlin/TextUtils.kt
+++ b/src/main/kotlin/TextUtils.kt
@@ -18,8 +18,9 @@ class TextUtils {
         }
     }
 
-    private fun targetTable(namespace: String, tableName: String) =
-        coalescedName("$namespace:$tableName")?.replace("-", "_")
+    fun targetTable(namespace: String, tableName: String) =
+        coalescedName("$namespace:$tableName")
+            ?.replace("-", "_")?.replace(".", "_")
 
     fun coalescedName(tableName: String) =
         if (coalescedNames[tableName] != null) coalescedNames[tableName] else tableName

--- a/src/test/kotlin/MetadataStoreClientTest.kt
+++ b/src/test/kotlin/MetadataStoreClientTest.kt
@@ -6,83 +6,88 @@ import java.sql.PreparedStatement
 import java.sql.Timestamp
 
 
-class MetadataStoreClientTest : StringSpec({
+class MetadataStoreClientTest : StringSpec() {
 
-    "Batch insert" {
-        val statement = mock<PreparedStatement>()
-        val sql = insertSql()
-
-        val connection = mock<Connection> {
-            on { prepareStatement(sql) } doReturn statement
-        }
-
-        val client = MetadataStoreClient(connection)
-        val payloads = (1..100).map { payloadNumber ->
-            val record: ConsumerRecord<ByteArray, ByteArray> = mock {
-                on { topic() } doReturn "db.database.collection$payloadNumber"
-                on { partition() } doReturn payloadNumber
-                on { offset() } doReturn payloadNumber.toLong()
-            }
-            HbasePayload("key-$payloadNumber".toByteArray(), "body-$payloadNumber".toByteArray(),
-                    payloadNumber.toLong(), record)
-        }
-
-
-        client.recordSuccessfulBatch(payloads)
-        verify(connection, times(1)).prepareStatement(sql)
-        verifyNoMoreInteractions(connection)
-
-        val textUtils = TextUtils()
-        for (i in 1..100) {
-            verify(statement, times(1)).setString(1, textUtils.printableKey("key-$i".toByteArray()))
-            verify(statement, times(1)).setTimestamp(2, Timestamp(i.toLong()))
-            verify(statement, times(1)).setString(3, "db.database.collection$i")
-            verify(statement, times(1)).setInt(4, i)
-            verify(statement, times(1)).setLong(5, i.toLong())
-        }
-        verify(statement, times(100)).addBatch()
-        verify(statement, times(1)).executeBatch()
-        verifyNoMoreInteractions(statement)
-    }
-
-    "Single insert" {
-        val statement = mock<PreparedStatement>()
-        val sql = insertSql()
-
-        val connection = mock<Connection> {
-            on { prepareStatement(sql) } doReturn statement
-        }
-
-        val client = MetadataStoreClient(connection)
-        val partition = 1
-        val offset = 2L
-        val id = "ID"
-        val topic = "db.database.collection"
-
-        val record: ConsumerRecord<ByteArray, ByteArray> = mock {
-            on { topic() } doReturn topic
-            on { partition() } doReturn partition
-            on { offset() } doReturn offset
-        }
-
-        val lastUpdated = 1L
-        client.recordProcessingAttempt(id, record, lastUpdated)
-        verify(connection, times(1)).prepareStatement(sql)
-        verifyNoMoreInteractions(connection)
-        verify(statement, times(1)).setString(1, id)
-        verify(statement, times(1)).setTimestamp(2, Timestamp(lastUpdated))
-        verify(statement, times(1)).setString(3, topic)
-        verify(statement, times(1)).setInt(4, partition)
-        verify(statement, times(1)).setLong(5, offset)
-        verify(statement, times(1)).executeUpdate()
-        verifyNoMoreInteractions(statement)
-    }
-
-})
-
-private fun insertSql(): String {
-    return """
+    private fun insertSql(): String {
+        return """
             INSERT INTO ucfs (hbase_id, hbase_timestamp, topic_name, kafka_partition, kafka_offset)
             VALUES (?, ?, ?, ?, ?)
         """.trimIndent()
+    }
+
+    init {
+
+        "Batch insert" {
+            val statement = mock<PreparedStatement>()
+            val sql = insertSql()
+
+            val connection = mock<Connection> {
+                on { prepareStatement(sql) } doReturn statement
+            }
+
+            val client = MetadataStoreClient(connection)
+            val payloads = (1..100).map { payloadNumber ->
+                val record: ConsumerRecord<ByteArray, ByteArray> = mock {
+                    on { topic() } doReturn "db.database.collection$payloadNumber"
+                    on { partition() } doReturn payloadNumber
+                    on { offset() } doReturn payloadNumber.toLong()
+                }
+                HbasePayload(
+                    "key-$payloadNumber".toByteArray(), "body-$payloadNumber".toByteArray(),
+                    payloadNumber.toLong(), record
+                )
+            }
+
+
+            client.recordSuccessfulBatch(payloads)
+            verify(connection, times(1)).prepareStatement(sql)
+            verifyNoMoreInteractions(connection)
+
+            val textUtils = TextUtils()
+            for (i in 1..100) {
+                verify(statement, times(1)).setString(1, textUtils.printableKey("key-$i".toByteArray()))
+                verify(statement, times(1)).setTimestamp(2, Timestamp(i.toLong()))
+                verify(statement, times(1)).setString(3, "db.database.collection$i")
+                verify(statement, times(1)).setInt(4, i)
+                verify(statement, times(1)).setLong(5, i.toLong())
+            }
+            verify(statement, times(100)).addBatch()
+            verify(statement, times(1)).executeBatch()
+            verifyNoMoreInteractions(statement)
+        }
+
+        "Single insert" {
+            val statement = mock<PreparedStatement>()
+            val sql = insertSql()
+
+            val connection = mock<Connection> {
+                on { prepareStatement(sql) } doReturn statement
+            }
+
+            val client = MetadataStoreClient(connection)
+            val partition = 1
+            val offset = 2L
+            val id = "ID"
+            val topic = "db.database.collection"
+
+            val record: ConsumerRecord<ByteArray, ByteArray> = mock {
+                on { topic() } doReturn topic
+                on { partition() } doReturn partition
+                on { offset() } doReturn offset
+            }
+
+            val lastUpdated = 1L
+            client.recordProcessingAttempt(id, record, lastUpdated)
+            verify(connection, times(1)).prepareStatement(sql)
+            verifyNoMoreInteractions(connection)
+            verify(statement, times(1)).setString(1, id)
+            verify(statement, times(1)).setTimestamp(2, Timestamp(lastUpdated))
+            verify(statement, times(1)).setString(3, topic)
+            verify(statement, times(1)).setInt(4, partition)
+            verify(statement, times(1)).setLong(5, offset)
+            verify(statement, times(1)).executeUpdate()
+            verifyNoMoreInteractions(statement)
+        }
+
+    }
 }

--- a/src/test/kotlin/TextUtilsTest.kt
+++ b/src/test/kotlin/TextUtilsTest.kt
@@ -8,6 +8,11 @@ class TextUtilsTest : StringSpec({
         Config.Hbase.qualifiedTablePattern = """^\w+\.([-\w]+)\.([-\w]+)$"""
     }
 
+    "table names will have dots and dashes replaced" {
+        val actual = TextUtils().targetTable("a.b-c", "d.e-f")
+        actual shouldBe "a_b_c:d_e_f"
+    }
+
     "agent_core:agentToDoArchive is coalesced." {
         val actual = TextUtils().coalescedName("agent_core:agentToDoArchive")
         actual shouldBe "agent_core:agentToDo"

--- a/src/test/kotlin/TextUtilsTest.kt
+++ b/src/test/kotlin/TextUtilsTest.kt
@@ -13,6 +13,11 @@ class TextUtilsTest : StringSpec({
         actual shouldBe "a_b_c:d_e_f"
     }
 
+    "table names will have dots and dashes replaced in edge case topic names" {
+        val actual = TextUtils().targetTable("ucfs", "data.encrypted")
+        actual shouldBe "ucfs:data_encrypted"
+    }
+
     "agent_core:agentToDoArchive is coalesced." {
         val actual = TextUtils().coalescedName("agent_core:agentToDoArchive")
         actual shouldBe "agent_core:agentToDo"
@@ -40,11 +45,11 @@ class TextUtilsTest : StringSpec({
 
         assert(result!!.groupValues[1] == "ucfs")
         assert(result.groupValues[2] == "data")
-
         reset()
     }
 
     "Test topic name table matcher will use ucfs data feed regex to match against valid table name with extra stanza" {
+        // extra stanza test for UC edge cases in topic names
 
         val tableName = "db.ucfs.data.encrypted"
 
@@ -56,7 +61,6 @@ class TextUtilsTest : StringSpec({
 
         assert(result!!.groupValues[1] == "ucfs")
         assert(result.groupValues[2] == "data.encrypted")
-
         reset()
     }
 

--- a/src/test/kotlin/TextUtilsTest.kt
+++ b/src/test/kotlin/TextUtilsTest.kt
@@ -44,6 +44,22 @@ class TextUtilsTest : StringSpec({
         reset()
     }
 
+    "Test topic name table matcher will use ucfs data feed regex to match against valid table name with extra stanza" {
+
+        val tableName = "db.ucfs.data.encrypted"
+
+        Config.Hbase.qualifiedTablePattern = """^\w+\.([-\w]+)\.([-\w]+)$"""
+
+        val result = TextUtils().topicNameTableMatcher(tableName)
+
+        result shouldNotBe null
+
+        assert(result!!.groupValues[1] == "ucfs")
+        assert(result.groupValues[2] == "data.encrypted")
+
+        reset()
+    }
+
     "Test topic name table matcher will use data equalities regex to match against valid table name" {
 
         val tableName = "data.equality_1324324234"

--- a/src/test/kotlin/TextUtilsTest.kt
+++ b/src/test/kotlin/TextUtilsTest.kt
@@ -5,7 +5,7 @@ import io.kotlintest.specs.StringSpec
 class TextUtilsTest : StringSpec({
 
     fun reset() {
-        Config.Hbase.qualifiedTablePattern = """^\w+\.([-\w]+)\.([-\w]+)$"""
+        Config.Hbase.qualifiedTablePattern = Config.Hbase.DEFAULT_QUALIFIED_TABLE_PATTERN
     }
 
     "table names will have dots and dashes replaced" {
@@ -37,7 +37,7 @@ class TextUtilsTest : StringSpec({
 
         val tableName = "db.ucfs.data"
 
-        Config.Hbase.qualifiedTablePattern = """^\w+\.([-\w]+)\.([-\w]+)$"""
+        Config.Hbase.qualifiedTablePattern = Config.Hbase.DEFAULT_QUALIFIED_TABLE_PATTERN
 
         val result = TextUtils().topicNameTableMatcher(tableName)
 
@@ -53,7 +53,7 @@ class TextUtilsTest : StringSpec({
 
         val tableName = "db.ucfs.data.encrypted"
 
-        Config.Hbase.qualifiedTablePattern = """^\w+\.([-\w]+)\.([-\w]+)$"""
+        Config.Hbase.qualifiedTablePattern = Config.Hbase.DEFAULT_QUALIFIED_TABLE_PATTERN
 
         val result = TextUtils().topicNameTableMatcher(tableName)
 


### PR DESCRIPTION
Support blank record key in DLQ actions. 
Support dots and dashed in table names (both changed to underscores).
Allow dot on table name to support topics like "db.core.somename.extraname" becoming a table like "core:somename_extraname".
