### PR TITLE
Write entire kafka batch as single manifest.

### DIFF
--- a/src/integration/kotlin/Kafka2hbEqualityIntegrationSpec.kt
+++ b/src/integration/kotlin/Kafka2hbEqualityIntegrationSpec.kt
@@ -37,7 +37,7 @@ class Kafka2hbEqualityIntegrationSpec : StringSpec() {
 
             val body = wellFormedValidPayloadEquality()
             val timestamp = converter.getTimestampAsLong(getISO8601Timestamp())
-            val (recordId, hbaseKey) = parser.generateKey(converter.convertToJson(getEqualityId().toByteArray()))
+            val (_, hbaseKey) = parser.generateKey(converter.convertToJson(getEqualityId().toByteArray()))
             println("Sending well-formed record to kafka topic '$topic'.")
             producer.sendRecord(topic.toByteArray(), "key1".toByteArray(), body, timestamp)
             println("Sent well-formed record to kafka topic '$topic'.")
@@ -69,7 +69,7 @@ class Kafka2hbEqualityIntegrationSpec : StringSpec() {
             val tableName = matcher.groupValues[2]
             val qualifiedTableName = sampleQualifiedTableName(namespace, tableName)
             val kafkaTimestamp1 = converter.getTimestampAsLong(getISO8601Timestamp())
-            val (recordId, hbaseKey) = parser.generateKey(converter.convertToJson(getEqualityId().toByteArray()))
+            val (_, hbaseKey) = parser.generateKey(converter.convertToJson(getEqualityId().toByteArray()))
             val body1 = wellFormedValidPayloadEquality()
             hbase.putVersion(qualifiedTableName, hbaseKey, body1, kafkaTimestamp1)
 

--- a/src/integration/kotlin/Kafka2hbUcfsIntegrationSpec.kt
+++ b/src/integration/kotlin/Kafka2hbUcfsIntegrationSpec.kt
@@ -44,7 +44,7 @@ class Kafka2hbUcfsIntegrationSpec : StringSpec() {
 
             val body = wellFormedValidPayload(namespace, tableName)
             val timestamp = converter.getTimestampAsLong(getISO8601Timestamp())
-            val (recordId, hbaseKey) = parser.generateKey(converter.convertToJson(getId().toByteArray()))
+            val (_, hbaseKey) = parser.generateKey(converter.convertToJson(getId().toByteArray()))
             log.info("Sending well-formed record to kafka topic '$topic'.")
             producer.sendRecord(topic.toByteArray(), "key1".toByteArray(), body, timestamp)
             log.info("Sent well-formed record to kafka topic '$topic'.")
@@ -74,7 +74,7 @@ class Kafka2hbUcfsIntegrationSpec : StringSpec() {
             hbase.ensureTable(qualifiedTableName)
             val body = wellFormedValidPayload("agent_core", "agentToDoArchive")
             val timestamp = converter.getTimestampAsLong(getISO8601Timestamp())
-            val (recordId, hbaseKey) = parser.generateKey(converter.convertToJson(getId().toByteArray()))
+            val (_, hbaseKey) = parser.generateKey(converter.convertToJson(getId().toByteArray()))
             log.info("Sending well-formed record to kafka topic '$topic'.")
             producer.sendRecord(topic.toByteArray(), "key1".toByteArray(), body, timestamp)
             log.info("Sent well-formed record to kafka topic '$topic'.")
@@ -96,7 +96,7 @@ class Kafka2hbUcfsIntegrationSpec : StringSpec() {
             val converter = Converter()
             val topic = uniqueTopicName()
             val matcher = TextUtils().topicNameTableMatcher(topic)!!
-            val (recordId, hbaseKey) = parser.generateKey(converter.convertToJson(getId().toByteArray()))
+            val (_, hbaseKey) = parser.generateKey(converter.convertToJson(getId().toByteArray()))
             val namespace = matcher.groupValues[1]
             val tableName = matcher.groupValues[2]
             val qualifiedTableName = sampleQualifiedTableName(namespace, tableName)
@@ -199,7 +199,7 @@ class Kafka2hbUcfsIntegrationSpec : StringSpec() {
 
             val body = wellFormedValidPayload(namespace, tableName)
             val timestamp = converter.getTimestampAsLong(getISO8601Timestamp())
-            val (recordId, hbaseKey) = parser.generateKey(converter.convertToJson(getId().toByteArray()))
+            val (_, hbaseKey) = parser.generateKey(converter.convertToJson(getId().toByteArray()))
             log.info("Sending well-formed record to kafka topic '$topic'.")
             producer.sendRecord(topic.toByteArray(), "key1".toByteArray(), body, timestamp)
             log.info("Sent well-formed record to kafka topic '$topic'.")

--- a/src/integration/resources/logback.xml
+++ b/src/integration/resources/logback.xml
@@ -1,0 +1,12 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/src/main/kotlin/ArchiveAwsS3Service.kt
+++ b/src/main/kotlin/ArchiveAwsS3Service.kt
@@ -1,8 +1,4 @@
 
-import Config.AwsS3.localstackAccessKey
-import Config.AwsS3.localstackSecretKey
-import Config.AwsS3.localstackServiceEndPoint
-import Config.dataworksRegion
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.ObjectMetadata
 import com.amazonaws.services.s3.model.PutObjectRequest

--- a/src/main/kotlin/Config.kt
+++ b/src/main/kotlin/Config.kt
@@ -25,7 +25,7 @@ fun getEnv(envVar: String): String? {
     return if (value.isNullOrEmpty()) null else value
 }
 
-fun String.toDuration() = Duration.parse(this)
+fun String.toDuration(): Duration = Duration.parse(this)
 fun readFile(fileName: String): String = File(fileName).readText(Charsets.UTF_8)
 
 object Config {
@@ -148,13 +148,13 @@ object Config {
     }
 
     object AwsS3 {
-        val maxS3Connections: Int = (getEnv("K2HB_AWS_S3_MAX_CONNECTIONS") ?: "2000").toInt()
-        val useLocalStack = (getEnv("K2HB_AWS_S3_USE_LOCALSTACK") ?: "false").toBoolean()
-        val region = getEnv("K2HB_AWS_S3_REGION") ?: dataworksRegion
+        private val maxS3Connections: Int = (getEnv("K2HB_AWS_S3_MAX_CONNECTIONS") ?: "2000").toInt()
+        private val useLocalStack = (getEnv("K2HB_AWS_S3_USE_LOCALSTACK") ?: "false").toBoolean()
+        private val region = getEnv("K2HB_AWS_S3_REGION") ?: dataworksRegion
 
-        const val localstackServiceEndPoint = "http://aws-s3:4566/"
-        const val localstackAccessKey = "AWS_ACCESS_KEY_ID"
-        const val localstackSecretKey = "AWS_SECRET_ACCESS_KEY"
+        private const val localstackServiceEndPoint = "http://aws-s3:4566/"
+        private const val localstackAccessKey = "AWS_ACCESS_KEY_ID"
+        private const val localstackSecretKey = "AWS_SECRET_ACCESS_KEY"
 
         val s3: AmazonS3 by lazy {
             if (useLocalStack) {

--- a/src/main/kotlin/Converter.kt
+++ b/src/main/kotlin/Converter.kt
@@ -54,7 +54,7 @@ open class Converter {
         val lastModifiedTimestampStr = json?.lookup<String?>("message._lastModifiedDateTime")?.get(0)
 
         if (recordType == "MONGO_DELETE") {
-            val kafkaTimestampStr = json?.lookup<String?>("timestamp")?.get(0)
+            val kafkaTimestampStr = json.lookup<String?>("timestamp")[0]
             if (!kafkaTimestampStr.isNullOrBlank()) {
                 return Pair(kafkaTimestampStr, "kafkaMessageDateTime")
             }

--- a/src/main/kotlin/CustomException.kt
+++ b/src/main/kotlin/CustomException.kt
@@ -1,3 +1,2 @@
 class DlqException(message: String) : Exception(message)
 class HbaseWriteException(message: String) : Exception(message)
-class HbaseConnectionException(message: String) : Exception(message)

--- a/src/main/kotlin/HbaseClient.kt
+++ b/src/main/kotlin/HbaseClient.kt
@@ -201,7 +201,7 @@ open class HbaseClient(val connection: Connection, private val columnFamily: Byt
             logger.info("Hbase connection configuration",
                     HConstants.ZOOKEEPER_ZNODE_PARENT, Config.Hbase.config.get(HConstants.ZOOKEEPER_ZNODE_PARENT),
                     HConstants.ZOOKEEPER_QUORUM, Config.Hbase.config.get(HConstants.ZOOKEEPER_QUORUM),
-                    "hbase.zookeeper.port", "${Config.Hbase.config.get("hbase.zookeeper.port")}")
+                    "hbase.zookeeper.port", Config.Hbase.config.get("hbase.zookeeper.port"))
 
             return HbaseClient(
                     ConnectionFactory.createConnection(HBaseConfiguration.create(Config.Hbase.config)),

--- a/src/test/kotlin/ListProcessorTest.kt
+++ b/src/test/kotlin/ListProcessorTest.kt
@@ -190,8 +190,8 @@ class ListProcessorTest : StringSpec() {
                 }
             })
 
-    private fun archiveAwsS3Service(): ArchiveAwsS3Service = mock<ArchiveAwsS3Service> { on { runBlocking { putObjects(any(), any()) } } doAnswer { } }
-    private fun manifestAwsS3Service(): ManifestAwsS3Service = mock<ManifestAwsS3Service> { on { runBlocking { putManifestFile(any(), any()) } } doAnswer { } }
+    private fun archiveAwsS3Service(): ArchiveAwsS3Service = mock { on { runBlocking { putObjects(any(), any()) } } doAnswer { } }
+    private fun manifestAwsS3Service(): ManifestAwsS3Service = mock { on { runBlocking { putManifestFile(any()) } } doAnswer { } }
     
     private fun json(id: Any) = """{ "message": { "_id": { "id": "$id" } } }"""
     private fun topicName(topicNumber: Int) = "db.database%02d.collection%02d".format(topicNumber, topicNumber)


### PR DESCRIPTION
Previously each manifest file represented 1 topic's worth of manifest
entries. To reduce the number of manifest files written to s3 the entire
batch returned from the kafka pollis written as a single manifest file.

The manifest files will now contain entries from multiple topics.
