### PR TITLE
Add region splits for k2hb when creating a table

### DIFF
--- a/src/integration/kotlin/lib/IntegrationTestUtils.kt
+++ b/src/integration/kotlin/lib/IntegrationTestUtils.kt
@@ -119,3 +119,5 @@ fun verifyMetadataStore(expectedCount: Int, expectedTopicName: String, exactMatc
             }
         }
     }
+
+fun testTables(): MutableSet<String> = HbaseClient.connect().tables.keys

--- a/src/integration/kotlin/lib/IntegrationTestUtils.kt
+++ b/src/integration/kotlin/lib/IntegrationTestUtils.kt
@@ -9,18 +9,27 @@ import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import io.kotest.matchers.longs.shouldBeGreaterThanOrEqual
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
+import org.apache.hadoop.hbase.TableName
 import java.sql.Connection
 import java.sql.DriverManager
 import java.text.SimpleDateFormat
 import java.time.Instant
 import java.util.*
+import kotlin.time.minutes
+import kotlin.time.seconds
 
 fun getId() = """{ "exampleId": "aaaa1111-abcd-4567-1234-1234567890ab"}"""
 
 fun getEqualityId() = """{ "messageId": "aaaa1111-abcd-4567-4321-1234567890ab"}"""
 
-fun wellFormedValidPayload(dbName: String = "exampleDbName",
-                           collectionName: String = "exampleCollectionName") = """{
+fun wellFormedValidPayload(
+    dbName: String = "exampleDbName",
+    collectionName: String = "exampleCollectionName"
+) = """{
         "traceId": "00001111-abcd-4567-1234-1234567890ab",
         "unitOfWorkId": "00002222-abcd-4567-1234-1234567890ab",
         "@type": "V4",
@@ -99,7 +108,8 @@ fun metadataStoreConnection(): Connection {
 fun verifyMetadataStore(expectedCount: Int, expectedTopicName: String, exactMatch: Boolean = true) =
     metadataStoreConnection().use { connection ->
         connection.createStatement().use { statement ->
-            val results = statement.executeQuery("SELECT count(*) FROM ucfs WHERE topic_name like '%$expectedTopicName%'")
+            val results =
+                statement.executeQuery("SELECT count(*) FROM ucfs WHERE topic_name like '%$expectedTopicName%'")
             results.next() shouldBe true
             val count = results.getLong(1)
             if (exactMatch) {

--- a/src/main/kotlin/Config.kt
+++ b/src/main/kotlin/Config.kt
@@ -19,6 +19,8 @@ import java.io.File
 import java.time.Duration
 import java.util.*
 import java.util.regex.Pattern
+import kotlin.time.ExperimentalTime
+import kotlin.time.hours
 
 fun getEnv(envVar: String): String? {
     val value = System.getenv(envVar)
@@ -69,6 +71,9 @@ object Config {
         val logKeys: Boolean = getEnv("K2HB_HBASE_LOG_KEYS")?.toBoolean() ?: true
         var DEFAULT_QUALIFIED_TABLE_PATTERN = """^\w+\.([-\w]+)\.([-.\w]+)$"""
         var qualifiedTablePattern = getEnv("K2HB_QUALIFIED_TABLE_PATTERN") ?: DEFAULT_QUALIFIED_TABLE_PATTERN
+        val regionSplits = getEnv("K2HB_HBASE_REGION_SPLITS") ?: "2"
+        @ExperimentalTime
+        val creationTimeoutSeconds = getEnv("K2HB_HBASE_CREATION_TIMEOUT_SECONDS")?.toInt() ?: 1.hours.inSeconds.toInt()
     }
 
     object Kafka {

--- a/src/main/kotlin/HbaseClient.kt
+++ b/src/main/kotlin/HbaseClient.kt
@@ -76,7 +76,6 @@ open class HbaseClient(
         }
     }
 
-
     private fun attemptPut(tableName: String, key: ByteArray, version: Long, body: ByteArray) {
 
         connection.getTable(TableName.valueOf(tableName)).use { table ->
@@ -175,7 +174,7 @@ open class HbaseClient(
         try {
             logger.info("Creating table",
                 "table_name", hbaseTable.nameAsString,
-                "region_splits", "$splits")
+                "region_splits", "$regionSplits")
 
             connection.admin.createTable(hbaseTable, splits.toTypedArray())
         } catch (e: TableExistsException) {
@@ -188,6 +187,8 @@ open class HbaseClient(
         }
     }
 
+    open fun getTableRegions(tableName: TableName): MutableList<HRegionInfo> = connection.admin.getTableRegions(tableName)
+
     private val namespaces by lazy {
         val extantNamespaces = mutableMapOf<String, Boolean>()
 
@@ -199,7 +200,7 @@ open class HbaseClient(
         extantNamespaces
     }
 
-    private val tables by lazy {
+    val tables by lazy {
         val names = mutableMapOf<String, Boolean>()
 
         connection.admin.listTableNames().forEach {

--- a/src/main/kotlin/HbaseClient.kt
+++ b/src/main/kotlin/HbaseClient.kt
@@ -1,4 +1,3 @@
-
 import org.apache.hadoop.hbase.*
 import org.apache.hadoop.hbase.client.*
 import org.apache.hadoop.hbase.io.TimeRange
@@ -6,8 +5,10 @@ import org.apache.hadoop.hbase.io.compress.Compression.Algorithm
 import java.io.IOException
 import kotlin.system.measureTimeMillis
 
-open class HbaseClient(val connection: Connection, private val columnFamily: ByteArray,
-                       private val columnQualifier: ByteArray, private val hbaseRegionReplication: Int): AutoCloseable {
+open class HbaseClient(
+    val connection: Connection, private val columnFamily: ByteArray,
+    private val columnQualifier: ByteArray, private val hbaseRegionReplication: Int
+) : AutoCloseable {
 
     @Throws(IOException::class)
     open fun putList(tableName: String, payloads: List<HbasePayload>) {
@@ -43,18 +44,14 @@ open class HbaseClient(val connection: Connection, private val columnFamily: Byt
                     "max_attempts", "${Config.Hbase.retryMaxAttempts}", "retry_delay", "$delay", "error_message","${e.message}")
                 Thread.sleep(delay)
                 exception = e
-            }
-            finally {
+            } finally {
                 attempts++
             }
         }
 
-        if (!success) {
-            if (exception != null) {
-                throw exception
-            }
+        if (!success && exception != null) {
+            throw exception
         }
-
     }
 
     @Throws(Exception::class)
@@ -94,8 +91,10 @@ open class HbaseClient(val connection: Connection, private val columnFamily: Byt
                     })
 
                     if (!exists) {
-                        logger.warn("Put record does not exist","attempts", "$attempts",
-                            "key", textUtils.printableKey(key), "table", tableName, "version", "$version")
+                        logger.warn(
+                            "Put record does not exist", "attempts", "$attempts",
+                            "key", textUtils.printableKey(key), "table", tableName, "version", "$version"
+                        )
                         if (++attempts >= Config.Hbase.maxExistenceChecks) {
                             logger.error("Put record does not exist after max retry attempts",
                                 "attempts", "$attempts", "key", textUtils.printableKey(key), "table", tableName, "version", "$version")
@@ -143,35 +142,49 @@ open class HbaseClient(val connection: Connection, private val columnFamily: Byt
             try {
                 logger.info("Creating namespace", "namespace", namespace)
                 connection.admin.createNamespace(NamespaceDescriptor.create(namespace).build())
-            }
-            catch (e: NamespaceExistException) {
+            } catch (e: NamespaceExistException) {
                 logger.info("Namespace already exists, probably created by another process", "namespace", namespace)
-            }
-            finally {
+            } finally {
                 namespaces[namespace] = true
             }
         }
 
         if (!tables.contains(tableName)) {
-            logger.info("Creating table", "table_name", "$dataTableName")
-            try {
-                connection.admin.createTable(HTableDescriptor(dataTableName).apply {
-                    addFamily(
-                        HColumnDescriptor(columnFamily)
-                            .apply {
-                                maxVersions = Int.MAX_VALUE
-                                minVersions = 1
-                                compressionType = Algorithm.GZ
-                                compactionCompressionType = Algorithm.GZ
-                            })
-                    regionReplication = hbaseRegionReplication
-                })
-            } catch (e: TableExistsException) {
-                logger.info("Didn't create table, table already exists, probably created by another process",
-                    "table_name", tableName)
-            } finally {
-                tables[tableName] = true
+
+            val hbaseTable = HTableDescriptor(dataTableName).apply {
+                addFamily(
+                    HColumnDescriptor(columnFamily)
+                        .apply {
+                            maxVersions = Int.MAX_VALUE
+                            minVersions = 1
+                            compressionType = Algorithm.GZ
+                            compactionCompressionType = Algorithm.GZ
+                        })
+                regionReplication = hbaseRegionReplication
             }
+
+            createTableInHbase(hbaseTable)
+        }
+    }
+
+    private fun createTableInHbase(hbaseTable: HTableDescriptor) {
+
+        val regionSplits = Config.Hbase.regionSplits.toInt()
+        val splits = calculateSplits(regionSplits)
+
+        try {
+            logger.info("Creating table",
+                "table_name", hbaseTable.nameAsString,
+                "region_splits", "$splits")
+
+            connection.admin.createTable(hbaseTable, splits.toTypedArray())
+        } catch (e: TableExistsException) {
+            logger.info(
+                "Didn't create table, table already exists, probably created by another process",
+                "table_name", hbaseTable.nameAsString
+            )
+        } finally {
+            tables[hbaseTable.nameAsString] = true
         }
     }
 
@@ -198,23 +211,24 @@ open class HbaseClient(val connection: Connection, private val columnFamily: Byt
 
     companion object {
         fun connect(): HbaseClient {
-            logger.info("Hbase connection configuration",
-                    HConstants.ZOOKEEPER_ZNODE_PARENT, Config.Hbase.config.get(HConstants.ZOOKEEPER_ZNODE_PARENT),
-                    HConstants.ZOOKEEPER_QUORUM, Config.Hbase.config.get(HConstants.ZOOKEEPER_QUORUM),
-                    "hbase.zookeeper.port", Config.Hbase.config.get("hbase.zookeeper.port"))
+            logger.info(
+                "Hbase connection configuration",
+                HConstants.ZOOKEEPER_ZNODE_PARENT, Config.Hbase.config.get(HConstants.ZOOKEEPER_ZNODE_PARENT),
+                HConstants.ZOOKEEPER_QUORUM, Config.Hbase.config.get(HConstants.ZOOKEEPER_QUORUM),
+                "hbase.zookeeper.port", Config.Hbase.config.get("hbase.zookeeper.port")
+            )
 
             return HbaseClient(
-                    ConnectionFactory.createConnection(HBaseConfiguration.create(Config.Hbase.config)),
-                    Config.Hbase.columnFamily.toByteArray(),
-                    Config.Hbase.columnQualifier.toByteArray(),
-                    Config.Hbase.regionReplication)
+                ConnectionFactory.createConnection(HBaseConfiguration.create(Config.Hbase.config)),
+                Config.Hbase.columnFamily.toByteArray(),
+                Config.Hbase.columnQualifier.toByteArray(),
+                Config.Hbase.regionReplication
+            )
         }
 
         private val logger: JsonLoggerWrapper = JsonLoggerWrapper.getLogger(HbaseClient::class.toString())
         private val textUtils = TextUtils()
     }
 
-
     override fun close() = connection.close()
-
 }

--- a/src/main/kotlin/RegionKeySplitter.kt
+++ b/src/main/kotlin/RegionKeySplitter.kt
@@ -1,0 +1,26 @@
+fun calculateSplits(numberOfRegions: Int): List<ByteArray> {
+    // We expect to make one less Split than the number of Regions required.
+    // Each split will be offset, for example;
+    // If the total bytes was 100 and we wanted 4 Regions, we would want 3  evenly spaced and sized splits:
+    //   20->39, 40->59, 60->79
+
+    logger.info("regions: $numberOfRegions")
+
+    // We use the first two bytes of the keys, so here need 256^2
+    val totalBytes = 256 * 256
+    val widthPerSplit = totalBytes / numberOfRegions
+    var remainder = totalBytes % numberOfRegions
+    val positions = mutableListOf<Int>()
+    var previous = 0
+
+    for (split in 0 until numberOfRegions - 1) {
+        val next = previous + widthPerSplit + (if (remainder-- > 0) 1 else 0)
+        positions.add(next)
+        previous = next
+    }
+
+    return positions.map { bytePosition ->
+        //this is the start position and end position of each slice, which should be contiguous
+        byteArrayOf((bytePosition / 256).toByte(), (bytePosition % 256).toByte())
+    }
+}

--- a/src/test/kotlin/ListProcessorTest.kt
+++ b/src/test/kotlin/ListProcessorTest.kt
@@ -14,7 +14,6 @@ import java.io.IOException
 import java.sql.Connection
 import java.sql.PreparedStatement
 
-
 class ListProcessorTest : StringSpec() {
 
     init {

--- a/src/test/kotlin/RegionKeySplitterTest.kt
+++ b/src/test/kotlin/RegionKeySplitterTest.kt
@@ -1,0 +1,35 @@
+import io.kotest.core.spec.style.StringSpec
+import org.junit.jupiter.api.Assertions.assertEquals
+
+class RegionKeySplitterTest : StringSpec({
+    "Splits are equally sized" {
+        for (regionCount in 1..10_000) {
+            calculateSplits(regionCount).let { splits ->
+                assertEquals(regionCount - 1, splits.size)
+                gaps(splits).let { gaps ->
+                    gaps.indices.forEach { index ->
+                        assertEquals(expectedSize(regionCount, index), gaps[index])
+                    }
+                }
+            }
+        }
+    }
+})
+
+private fun expectedSize(regionCount: Int, index: Int) =
+    minimumSize(regionCount) + if (index < remainder(regionCount)) 1 else 0
+
+private fun gaps(splits: List<ByteArray>) =
+    splits.indices.map {
+        val position1 = if (it == 0) 0 else position(splits[it - 1])
+        val position2 = position(splits[it])
+        position2 - position1
+    }
+
+private fun remainder(regionCount: Int): Int = keyspaceSize % regionCount
+private fun minimumSize(regionCount: Int) = keyspaceSize / regionCount
+private fun position(digits: ByteArray): Int = toUnsigned(digits[0]) * 256 + toUnsigned(digits[1])
+private fun toUnsigned(byte: Byte): Int = if (byte < 0) (byte + 256) else byte.toInt()
+
+private const val keyspaceSize = 256 * 256
+


### PR DESCRIPTION
When a table does not exist in Hbase, K2HB will now partition it with a default value of 2 which will help with performance down the line.